### PR TITLE
Tailscale.sh: use --statedir instead of --state

### DIFF
--- a/Tailscale/shared/Tailscale.sh
+++ b/Tailscale/shared/Tailscale.sh
@@ -20,7 +20,7 @@ case "$1" in
           exit 0
         fi
     fi
-    ${QPKG_ROOT}/tailscaled --port 41641 --state=${QPKG_ROOT}/state/tailscaled.state --socket=/tmp/tailscale/tailscaled.sock 2> /dev/null &
+    ${QPKG_ROOT}/tailscaled --port 41641 --statedir=${QPKG_ROOT}/state --socket=/tmp/tailscale/tailscaled.sock 2> /dev/null &
     echo $! > /tmp/tailscale/tailscaled.pid
     ;;
 


### PR DESCRIPTION
Allows certificates to be generated.

Fixes https://github.com/tailscale/tailscale-qpkg/issues/63

Signed-off-by: Denton Gentry <dgentry@tailscale.com>