### PR TITLE
fixed script error

### DIFF
--- a/Tailscale/shared/Tailscale.sh
+++ b/Tailscale/shared/Tailscale.sh
@@ -15,7 +15,7 @@ case "$1" in
     mkdir -p -m 0755 /tmp/tailscale
     if [ -e /tmp/tailscale/tailscaled.pid ]; then
         PID=$(cat /tmp/tailscale/tailscaled.pid)
-        if [ test -d /proc/${PID}/ ]; then
+        if [ -d /proc/${PID}/ ]; then
           echo "${QPKG_NAME} is already running."
           exit 0
         fi


### PR DESCRIPTION
test -d leads to the following error:
./Tailscale.sh: line 18: [: -d: binary operator expected

-d is sufficient for the intended check

resolves #65