### PR TITLE
Fix CLI and move PID file

### DIFF
--- a/Tailscale/package_routines
+++ b/Tailscale/package_routines
@@ -112,6 +112,8 @@
 PKG_POST_REMOVE="{
     rm -f /home/httpd/cgi-bin/qpkg/Tailscale
     rm -rf /tmp/tailscale
+    rm -f /usr/sbin/tailscaled
+    rm -f /usr/sbin/tailscale    
 }"
 #
 ######################################################################
@@ -139,4 +141,6 @@ pkg_install(){
 pkg_post_install(){
     ${CMD_MKDIR} -p /home/httpd/cgi-bin/qpkg
     ${CMD_LN} -sf ${SYS_QPKG_DIR}/ui /home/httpd/cgi-bin/qpkg/${QPKG_NAME}
+    ${CMD_LN} -sf ${SYS_QPKG_DIR}/tailscaled /usr/sbin/tailscaled
+    ${CMD_LN} -sf ${SYS_QPKG_DIR}/tailscale /usr/sbin/tailscale
 }

--- a/Tailscale/shared/Tailscale.sh
+++ b/Tailscale/shared/Tailscale.sh
@@ -3,6 +3,9 @@ CONF=/etc/config/qpkg.conf
 QPKG_NAME="Tailscale"
 QPKG_ROOT=`/sbin/getcfg ${QPKG_NAME} Install_Path -f ${CONF}`
 export QNAP_QPKG=${QPKG_NAME}
+export QPKG_ROOT
+export QPKG_NAME
+export PIDF=/var/run/tailscaled.pid
 set -e
 
 case "$1" in
@@ -12,24 +15,31 @@ case "$1" in
         echo "${QPKG_NAME} is disabled."
         exit 1
     fi
-    mkdir -p -m 0755 /tmp/tailscale
-    if [ -e /tmp/tailscale/tailscaled.pid ]; then
-        PID=$(cat /tmp/tailscale/tailscaled.pid)
+
+    if [ -e ${PIDF} ]; then
+        PID=$(cat ${PIDF})
         if [ -d /proc/${PID}/ ]; then
           echo "${QPKG_NAME} is already running."
           exit 0
         fi
     fi
-    ${QPKG_ROOT}/tailscaled --port 41641 --statedir=${QPKG_ROOT}/state --socket=/tmp/tailscale/tailscaled.sock 2> /dev/null &
-    echo $! > /tmp/tailscale/tailscaled.pid
+    /bin/ln -sf ${QPKG_ROOT}/tailscaled /usr/bin/tailscaled
+    /bin/ln -sf ${QPKG_ROOT}/tailscale /usr/bin/tailscale
+    tailscaled --port 41641 --statedir=${QPKG_ROOT}/state 2> /dev/null &
+    echo $! > ${PIDF}
+    sleep 10
+    tailscale up 2>&1 > /dev/null | tee ${QPKG_ROOT}/tailscale.txt &
     ;;
 
   stop)
-    if [ -e /tmp/tailscale/tailscaled.pid ]; then
-      PID=$(cat /tmp/tailscale/tailscaled.pid)
+    tailscale down
+    if [ -e ${PIDF} ]; then
+      PID=$(cat ${PIDF})
       kill -9 ${PID} || true
-      rm -f /tmp/tailscale/tailscaled.pid
+      rm -f ${PIDF}
     fi
+    rm -rf /usr/bin/tailscaled
+    rm -rf /usr/bin/tailscale
     ;;
 
   restart)

--- a/Tailscale/shared/Tailscale.sh
+++ b/Tailscale/shared/Tailscale.sh
@@ -3,6 +3,7 @@ CONF=/etc/config/qpkg.conf
 QPKG_NAME="Tailscale"
 QPKG_ROOT=`/sbin/getcfg ${QPKG_NAME} Install_Path -f ${CONF}`
 export QNAP_QPKG=${QPKG_NAME}
+export PIDF=/var/run/tailscaled.pid
 set -e
 
 case "$1" in
@@ -13,22 +14,22 @@ case "$1" in
         exit 1
     fi
     mkdir -p -m 0755 /tmp/tailscale
-    if [ -e /tmp/tailscale/tailscaled.pid ]; then
-        PID=$(cat /tmp/tailscale/tailscaled.pid)
+    if [ -e ${PIDF} ]; then
+        PID=$(cat ${PIDF})
         if [ -d /proc/${PID}/ ]; then
           echo "${QPKG_NAME} is already running."
           exit 0
         fi
     fi
-    ${QPKG_ROOT}/tailscaled --port 41641 --statedir=${QPKG_ROOT}/state --socket=/tmp/tailscale/tailscaled.sock 2> /dev/null &
-    echo $! > /tmp/tailscale/tailscaled.pid
+    tailscaled --port 41641 --statedir=${QPKG_ROOT}/state 2> /dev/null &
+    echo $! > ${PIDF}
     ;;
 
   stop)
-    if [ -e /tmp/tailscale/tailscaled.pid ]; then
-      PID=$(cat /tmp/tailscale/tailscaled.pid)
+    if [ -e ${PIDF} ]; then
+      PID=$(cat ${PIDF})
       kill -9 ${PID} || true
-      rm -f /tmp/tailscale/tailscaled.pid
+      rm -f ${PIDF}
     fi
     ;;
 

--- a/Tailscale/shared/ui/index.cgi
+++ b/Tailscale/shared/ui/index.cgi
@@ -1,5 +1,2 @@
 #!/bin/sh
-CONF=/etc/config/qpkg.conf
-QPKG_NAME="Tailscale"
-QPKG_ROOT=$(/sbin/getcfg ${QPKG_NAME} Install_Path -f ${CONF} -d"")
-exec ${QPKG_ROOT}/tailscale --socket=/tmp/tailscale/tailscaled.sock web -cgi
+exec tailscale web -cgi


### PR DESCRIPTION
These adjustments do the following:

- Allows ones to use the CLI natively on a QNAP by adding symbolic links
- Relocates the PID file to the default location on QNAPs