### PR TITLE
index.cgi: pass path prefix to web CLI

### DIFF
--- a/Tailscale/shared/ui/index.cgi
+++ b/Tailscale/shared/ui/index.cgi
@@ -2,4 +2,4 @@
 CONF=/etc/config/qpkg.conf
 QPKG_NAME="Tailscale"
 QPKG_ROOT=$(/sbin/getcfg ${QPKG_NAME} Install_Path -f ${CONF} -d"")
-exec ${QPKG_ROOT}/tailscale --socket=/tmp/tailscale/tailscaled.sock web -cgi
+exec "${QPKG_ROOT}/tailscale" --socket=/tmp/tailscale/tailscaled.sock web --cgi --prefix="/cgi-bin/qpkg/Tailscale/index.cgi/"


### PR DESCRIPTION
prefix flag added in tailscale/tailscale#9189, and needed for new web client.